### PR TITLE
Detect qmake-qt5 as a valid alternative

### DIFF
--- a/configure
+++ b/configure
@@ -36,7 +36,7 @@
 ###########################################################################
 
 hash ruby 2>&- || { echo >&2 "Fatal error: Package \"ruby\" is not installed on your system. Aborting..."; exit 1; }
-hash qmake 2>&- || { echo >&2 "Fatal error: Package \"qmake\" is not installed on your system. Aborting..."; exit 1; }
+hash qmake 2>&- || hash qmake-qt5 2>&- || { echo >&2 "Fatal error: Package \"qmake\" is not installed on your system. Aborting..."; exit 1; }
 
 export RUBYLIB=.:${RUBYLIB}
 ruby configure.rb $*

--- a/qonf/qmake.rb
+++ b/qonf/qmake.rb
@@ -48,12 +48,12 @@ class QMake
 
     # This method check if the current version of Qt is valid for Tupi compilation    
     def findQMake(minqtversion, verbose, qtdir)
-        path = "qmake"
         command = ""
+        ["qmake", "qmake-qt5"].each do |path|
 
-        Info.info << "Testing for #{path}... "
+            Info.info << "Testing for #{path}... "
 
-        IO.popen("which #{path}") { |result|
+            IO.popen("which #{path}") { |result|
                  if qtdir.length > 0
                     command = qtdir + "/bin/qmake"
                  else
@@ -62,12 +62,14 @@ class QMake
                        command = pathVar[0].chop
                     end
                  end
-
-                 if command.length == 0
-                    return false
-                 end
-        }
-
+            }
+            if command.length != 0
+                break
+            end
+        end
+        if command.length == 0
+            return false
+        end
         qtversion = ""
         version = []
 


### PR DESCRIPTION
On Fedora 24, qmake for Qt5 is qmake-qt5. Detect that.

There are more issues downstream, I'll see about addressing them later.
